### PR TITLE
Fixed intent-filter and onMapIntentToUri

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,9 +66,10 @@
             android:authorities="com.example.android.sliceviewer"
             android:exported="true">
             <intent-filter>
-                <action android:name="androidx.intent.SLICE_ACTION" />
+                <action android:name="android.intent.action.VIEW" />
 
-                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.app.slice.category.SLICE" />
+
 
                 <data
                     android:host="sliceviewer.android.example.com"

--- a/app/src/main/java/com/example/android/sliceviewer/provider/SampleSliceProvider.kt
+++ b/app/src/main/java/com/example/android/sliceviewer/provider/SampleSliceProvider.kt
@@ -44,12 +44,11 @@ class SampleSliceProvider : SliceProvider() {
     override fun onCreateSliceProvider() = true
 
     override fun onMapIntentToUri(intent: Intent?): Uri {
-        super.onMapIntentToUri(intent)
         val path = intent?.data?.path ?: ""
         return Uri.Builder()
             .scheme(ContentResolver.SCHEME_CONTENT)
             .authority(context.packageName)
-            .appendPath(path)
+            .path(path)
             .build()
     }
 


### PR DESCRIPTION
The intent-filter seemed to be incorrect resulting in a unreachable SliceProvider.
The SampleSliceProvider made a call to a not implemented super onMapIntentToUri() function and appendPath caused the "/" to be encoded resulting in a unrecognized path in onBindSlice().